### PR TITLE
Add Wi-Fi media transfer feature

### DIFF
--- a/ios/QCSDKDemo.xcodeproj/project.pbxproj
+++ b/ios/QCSDKDemo.xcodeproj/project.pbxproj
@@ -13,7 +13,8 @@
 		AA1313892E2F904500B03938 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA1313792E2F904500B03938 /* Assets.xcassets */; };
 		AA13138B2E2F904500B03938 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA13137C2E2F904500B03938 /* LaunchScreen.storyboard */; };
 		AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */; };
-		AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */; };
+                AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */; };
+                AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */; };
 		AA13172A2E31290900B03938 /* QCSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1317282E3128F300B03938 /* QCSDK.framework */; };
 		AA13172B2E31290900B03938 /* QCSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AA1317282E3128F300B03938 /* QCSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
@@ -46,8 +47,10 @@
 		AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QCCentralManager.h; sourceTree = "<group>"; };
 		AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCCentralManager.m; sourceTree = "<group>"; };
 		AA1316AD2E2FBA0400B03938 /* QCScanViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QCScanViewController.h; sourceTree = "<group>"; };
-		AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCScanViewController.m; sourceTree = "<group>"; };
-		AA1317282E3128F300B03938 /* QCSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QCSDK.framework; sourceTree = SOURCE_ROOT; };
+                AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCScanViewController.m; sourceTree = "<group>"; };
+                AA1317282E3128F300B03938 /* QCSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QCSDK.framework; sourceTree = SOURCE_ROOT; };
+                AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlassesMediaDownloader.h; sourceTree = "<group>"; };
+                AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GlassesMediaDownloader.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,16 +82,18 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		AA1313842E2F904500B03938 /* QCSDKDemo */ = {
-			isa = PBXGroup;
-			children = (
-				AA1317282E3128F300B03938 /* QCSDK.framework */,
-				AA1313772E2F904500B03938 /* AppDelegate.h */,
-				AA1313782E2F904500B03938 /* AppDelegate.m */,
-				AA1313822E2F904500B03938 /* ViewController.h */,
-				AA1313832E2F904500B03938 /* ViewController.m */,
-				AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */,
-				AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */,
+                AA1313842E2F904500B03938 /* QCSDKDemo */ = {
+                        isa = PBXGroup;
+                        children = (
+                                AA1317282E3128F300B03938 /* QCSDK.framework */,
+                                AA1313772E2F904500B03938 /* AppDelegate.h */,
+                                AA1313782E2F904500B03938 /* AppDelegate.m */,
+                                AA1313822E2F904500B03938 /* ViewController.h */,
+                                AA1313832E2F904500B03938 /* ViewController.m */,
+                                AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */,
+                                AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */,
+                                AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */,
+                                AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */,
 				AA1316AD2E2FBA0400B03938 /* QCScanViewController.h */,
 				AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */,
 				AA1313792E2F904500B03938 /* Assets.xcassets */,
@@ -176,18 +181,19 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		AA1313532E2F903500B03938 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AA1313852E2F904500B03938 /* AppDelegate.m in Sources */,
-				AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */,
-				AA1313862E2F904500B03938 /* main.m in Sources */,
-				AA1313882E2F904500B03938 /* ViewController.m in Sources */,
-				AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                AA1313532E2F903500B03938 /* Sources */ = {
+                        isa = PBXSourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                AA1313852E2F904500B03938 /* AppDelegate.m in Sources */,
+                                AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */,
+                                AA1313862E2F904500B03938 /* main.m in Sources */,
+                                AA1313882E2F904500B03938 /* ViewController.m in Sources */,
+                                AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */,
+                                AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */

--- a/ios/QCSDKDemo.xcodeproj/project.pbxproj
+++ b/ios/QCSDKDemo.xcodeproj/project.pbxproj
@@ -7,16 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		BB9E74E1FE /* MediaGalleryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = BB48D45A88 /* MediaGalleryViewController.m */; };
 		AA1313852E2F904500B03938 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1313782E2F904500B03938 /* AppDelegate.m */; };
 		AA1313862E2F904500B03938 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AA13137D2E2F904500B03938 /* main.m */; };
 		AA1313882E2F904500B03938 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1313832E2F904500B03938 /* ViewController.m */; };
 		AA1313892E2F904500B03938 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AA1313792E2F904500B03938 /* Assets.xcassets */; };
 		AA13138B2E2F904500B03938 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA13137C2E2F904500B03938 /* LaunchScreen.storyboard */; };
 		AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */; };
-                AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */; };
-                AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */; };
+		AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */; };
 		AA13172A2E31290900B03938 /* QCSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA1317282E3128F300B03938 /* QCSDK.framework */; };
 		AA13172B2E31290900B03938 /* QCSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = AA1317282E3128F300B03938 /* QCSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */ = {isa = PBXBuildFile; fileRef = AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -34,6 +35,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		76BE5E782E847A3E008B17F4 /* QCSDKDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QCSDKDemo.entitlements; sourceTree = "<group>"; };
 		AA1313572E2F903500B03938 /* QCSDKDemo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QCSDKDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA1313772E2F904500B03938 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		AA1313782E2F904500B03938 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -47,10 +49,12 @@
 		AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QCCentralManager.h; sourceTree = "<group>"; };
 		AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCCentralManager.m; sourceTree = "<group>"; };
 		AA1316AD2E2FBA0400B03938 /* QCScanViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = QCScanViewController.h; sourceTree = "<group>"; };
-                AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCScanViewController.m; sourceTree = "<group>"; };
-                AA1317282E3128F300B03938 /* QCSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QCSDK.framework; sourceTree = SOURCE_ROOT; };
-                AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlassesMediaDownloader.h; sourceTree = "<group>"; };
-                AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GlassesMediaDownloader.m; sourceTree = "<group>"; };
+		AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = QCScanViewController.m; sourceTree = "<group>"; };
+		AA1317282E3128F300B03938 /* QCSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QCSDK.framework; sourceTree = SOURCE_ROOT; };
+		AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GlassesMediaDownloader.h; sourceTree = "<group>"; };
+		AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = GlassesMediaDownloader.m; sourceTree = "<group>"; };
+		BBEA4D0FAD /* MediaGalleryViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaGalleryViewController.h; sourceTree = "<group>"; };
+		BB48D45A88 /* MediaGalleryViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MediaGalleryViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -82,18 +86,21 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-                AA1313842E2F904500B03938 /* QCSDKDemo */ = {
-                        isa = PBXGroup;
-                        children = (
-                                AA1317282E3128F300B03938 /* QCSDK.framework */,
-                                AA1313772E2F904500B03938 /* AppDelegate.h */,
-                                AA1313782E2F904500B03938 /* AppDelegate.m */,
-                                AA1313822E2F904500B03938 /* ViewController.h */,
-                                AA1313832E2F904500B03938 /* ViewController.m */,
-                                AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */,
-                                AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */,
-                                AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */,
-                                AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */,
+		AA1313842E2F904500B03938 /* QCSDKDemo */ = {
+			isa = PBXGroup;
+			children = (
+				76BE5E782E847A3E008B17F4 /* QCSDKDemo.entitlements */,
+				AA1317282E3128F300B03938 /* QCSDK.framework */,
+				AA1313772E2F904500B03938 /* AppDelegate.h */,
+				AA1313782E2F904500B03938 /* AppDelegate.m */,
+				AA1313822E2F904500B03938 /* ViewController.h */,
+				AA1313832E2F904500B03938 /* ViewController.m */,
+				AA9999A02E40000000B03938 /* GlassesMediaDownloader.h */,
+				AA9999A12E40000000B03938 /* GlassesMediaDownloader.m */,
+				BBEA4D0FAD /* MediaGalleryViewController.h */,
+				BB48D45A88 /* MediaGalleryViewController.m */,
+				AA1313BA2E2F9E9800B03938 /* QCCentralManager.h */,
+				AA1313BB2E2F9E9800B03938 /* QCCentralManager.m */,
 				AA1316AD2E2FBA0400B03938 /* QCScanViewController.h */,
 				AA1316AE2E2FBA0400B03938 /* QCScanViewController.m */,
 				AA1313792E2F904500B03938 /* Assets.xcassets */,
@@ -181,19 +188,20 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-                AA1313532E2F903500B03938 /* Sources */ = {
-                        isa = PBXSourcesBuildPhase;
-                        buildActionMask = 2147483647;
-                        files = (
-                                AA1313852E2F904500B03938 /* AppDelegate.m in Sources */,
-                                AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */,
-                                AA1313862E2F904500B03938 /* main.m in Sources */,
-                                AA1313882E2F904500B03938 /* ViewController.m in Sources */,
-                                AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */,
-                                AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */,
-                        );
-                        runOnlyForDeploymentPostprocessing = 0;
-                };
+		AA1313532E2F903500B03938 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AA1313852E2F904500B03938 /* AppDelegate.m in Sources */,
+				AA1313BC2E2F9E9800B03938 /* QCCentralManager.m in Sources */,
+				AA1313862E2F904500B03938 /* main.m in Sources */,
+				AA1313882E2F904500B03938 /* ViewController.m in Sources */,
+				AA1316AF2E2FBA0400B03938 /* QCScanViewController.m in Sources */,
+				AA9999A22E40000000B03938 /* GlassesMediaDownloader.m in Sources */,
+				BB9E74E1FE /* MediaGalleryViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXVariantGroup section */
@@ -213,6 +221,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = QCSDKDemo/QCSDKDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 42R8ZPM5N8;
@@ -235,7 +244,7 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.qcwx.dev.QCSDKDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ebowwa.QCSDKDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 1;
@@ -247,6 +256,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = QCSDKDemo/QCSDKDemo.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 42R8ZPM5N8;
@@ -269,7 +279,7 @@
 				);
 				MARKETING_VERSION = 1.0.0;
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.qcwx.dev.QCSDKDemo;
+				PRODUCT_BUNDLE_IDENTIFIER = com.ebowwa.QCSDKDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				TARGETED_DEVICE_FAMILY = 1;

--- a/ios/QCSDKDemo/GlassesMediaDownloader.h
+++ b/ios/QCSDKDemo/GlassesMediaDownloader.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^GlassesMediaDownloaderStatusHandler)(NSString *status, UIImage * _Nullable previewImage);
+typedef void (^GlassesMediaDownloaderCompletionHandler)(NSError * _Nullable error);
+
+@interface GlassesMediaDownloader : NSObject
+
+- (instancetype)initWithStatusHandler:(GlassesMediaDownloaderStatusHandler)statusHandler NS_DESIGNATED_INITIALIZER;
+- (instancetype)init NS_UNAVAILABLE;
+
+- (void)startDownloadWithCompletion:(GlassesMediaDownloaderCompletionHandler)completion;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/QCSDKDemo/GlassesMediaDownloader.m
+++ b/ios/QCSDKDemo/GlassesMediaDownloader.m
@@ -1,0 +1,292 @@
+#import "GlassesMediaDownloader.h"
+
+#import <QCSDK/QCSDKCmdCreator.h>
+#import <NetworkExtension/NetworkExtension.h>
+
+static NSString * const GlassesMediaDownloaderErrorDomain = @"GlassesMediaDownloaderErrorDomain";
+
+typedef NS_ENUM(NSInteger, GlassesMediaDownloaderErrorCode) {
+    GlassesMediaDownloaderErrorCodeWifiCredentials = 1,
+    GlassesMediaDownloaderErrorCodeWifiIP,
+    GlassesMediaDownloaderErrorCodeHotspotUnavailable,
+    GlassesMediaDownloaderErrorCodeManifest,
+    GlassesMediaDownloaderErrorCodeDownload,
+    GlassesMediaDownloaderErrorCodeFilesystem
+};
+
+@interface GlassesMediaDownloader ()
+@property (nonatomic, copy) GlassesMediaDownloaderStatusHandler statusHandler;
+@property (nonatomic, copy) GlassesMediaDownloaderCompletionHandler completionHandler;
+@property (nonatomic, copy) NSString *ssid;
+@property (nonatomic, copy) NSString *password;
+@property (nonatomic, copy) NSString *deviceIP;
+@property (nonatomic, strong) NSURLSession *session;
+@property (nonatomic, assign) BOOL didFinish;
+@end
+
+@implementation GlassesMediaDownloader
+
+- (instancetype)initWithStatusHandler:(GlassesMediaDownloaderStatusHandler)statusHandler {
+    self = [super init];
+    if (self) {
+        _statusHandler = [statusHandler copy];
+        _session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration];
+    }
+    return self;
+}
+
+- (void)startDownloadWithCompletion:(GlassesMediaDownloaderCompletionHandler)completion {
+    self.completionHandler = [completion copy];
+    self.didFinish = NO;
+    [self updateStatus:@"Requesting Wi-Fi credentials..." preview:nil];
+    [self requestWifiCredentials];
+}
+
+#pragma mark - Flow
+
+- (void)requestWifiCredentials {
+    __weak typeof(self) weakSelf = self;
+    [QCSDKCmdCreator openWifiWithMode:QCOperatorDeviceModeTransfer success:^(NSString *ssid, NSString *password) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        strongSelf.ssid = ssid ?: @"";
+        strongSelf.password = password ?: @"";
+        [strongSelf updateStatus:[NSString stringWithFormat:@"Received hotspot: %@", ssid ?: @"<unknown>"] preview:nil];
+        [strongSelf requestDeviceIP];
+    } fail:^(NSInteger code) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        NSString *description = [NSString stringWithFormat:@"Failed to request Wi-Fi credentials (code %ld).", (long)code];
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiCredentials userInfo:@{NSLocalizedDescriptionKey : description}];
+        [strongSelf finishWithError:error];
+    }];
+}
+
+- (void)requestDeviceIP {
+    __weak typeof(self) weakSelf = self;
+    [self updateStatus:@"Retrieving device IP address..." preview:nil];
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (ipAddress.length == 0) {
+            NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Device did not report a Wi-Fi IP address."}];
+            [strongSelf finishWithError:error];
+            return;
+        }
+        strongSelf.deviceIP = ipAddress;
+        [strongSelf joinHotspot];
+    } failed:^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Failed to retrieve device Wi-Fi IP address."}];
+        [strongSelf finishWithError:error];
+    }];
+}
+
+- (void)joinHotspot {
+    [self updateStatus:@"Joining device hotspot..." preview:nil];
+    if (@available(iOS 11.0, *)) {
+        NEHotspotConfiguration *configuration = nil;
+        if (self.password.length > 0) {
+            configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid passphrase:self.password isWEP:NO];
+        } else {
+            configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid];
+        }
+        configuration.joinOnce = YES;
+        __weak typeof(self) weakSelf = self;
+        [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) { return; }
+            if (!error || error.code == NEHotspotConfigurationErrorAlreadyAssociated) {
+                [strongSelf updateStatus:@"Connected to device hotspot." preview:nil];
+                [strongSelf downloadManifest];
+            } else {
+                NSString *description = [NSString stringWithFormat:@"Unable to join hotspot (%@).", error.localizedDescription ?: @"unknown error"];
+                NSError *joinError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeHotspotUnavailable userInfo:@{NSLocalizedDescriptionKey : description}];
+                [strongSelf finishWithError:joinError];
+            }
+        }];
+    } else {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeHotspotUnavailable userInfo:@{NSLocalizedDescriptionKey : @"Hotspot configuration requires iOS 11 or later."}];
+        [self finishWithError:error];
+    }
+}
+
+- (void)downloadManifest {
+    NSString *manifestString = [NSString stringWithFormat:@"http://%@/files/media.config", self.deviceIP];
+    NSURL *manifestURL = [NSURL URLWithString:manifestString];
+    if (!manifestURL) {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"Invalid manifest URL."}];
+        [self finishWithError:error];
+        return;
+    }
+
+    [self updateStatus:@"Fetching media manifest..." preview:nil];
+    __weak typeof(self) weakSelf = self;
+    NSURLSessionDataTask *task = [self.session dataTaskWithURL:manifestURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (error) {
+            NSString *description = [NSString stringWithFormat:@"Failed to download manifest: %@", error.localizedDescription ?: @"unknown error"];
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            NSString *description = [NSString stringWithFormat:@"Manifest request returned HTTP %ld.", (long)httpResponse.statusCode];
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSString *configString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (!configString) {
+            configString = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+        }
+        if (configString.length == 0) {
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"Media manifest is empty."}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSArray<NSURL *> *fileURLs = [strongSelf fileURLsFromManifestString:configString baseURL:manifestURL];
+        [strongSelf prepareDownloadDirectoryWithManifest:fileURLs baseURL:manifestURL];
+    }];
+    [task resume];
+}
+
+- (NSArray<NSURL *> *)fileURLsFromManifestString:(NSString *)manifest baseURL:(NSURL *)manifestURL {
+    NSArray<NSString *> *lines = [manifest componentsSeparatedByCharactersInSet:NSCharacterSet.newlineCharacterSet];
+    NSMutableArray<NSURL *> *fileURLs = [NSMutableArray array];
+    NSURL *baseURL = [manifestURL URLByDeletingLastPathComponent];
+    for (NSString *line in lines) {
+        NSString *trimmed = [line stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (trimmed.length == 0) { continue; }
+        if ([trimmed hasPrefix:@"#"]) { continue; }
+        NSURL *resolvedURL = nil;
+        if ([trimmed hasPrefix:@"http://"] || [trimmed hasPrefix:@"https://"]) {
+            resolvedURL = [NSURL URLWithString:trimmed];
+        } else {
+            resolvedURL = [NSURL URLWithString:trimmed relativeToURL:baseURL];
+        }
+        if (resolvedURL) {
+            [fileURLs addObject:resolvedURL.absoluteURL];
+        }
+    }
+    return fileURLs.copy;
+}
+
+- (void)prepareDownloadDirectoryWithManifest:(NSArray<NSURL *> *)fileURLs baseURL:(NSURL *)manifestURL {
+    (void)manifestURL;
+    NSString *documentsDirectory = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES).firstObject;
+    if (documentsDirectory.length == 0) {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeFilesystem userInfo:@{NSLocalizedDescriptionKey : @"Unable to locate the Documents directory."}];
+        [self finishWithError:error];
+        return;
+    }
+
+    NSString *mediaDirectoryPath = [documentsDirectory stringByAppendingPathComponent:@"GlassesMedia"];
+    NSURL *mediaDirectoryURL = [NSURL fileURLWithPath:mediaDirectoryPath isDirectory:YES];
+
+    NSError *directoryError = nil;
+    if (![[NSFileManager defaultManager] createDirectoryAtURL:mediaDirectoryURL withIntermediateDirectories:YES attributes:nil error:&directoryError]) {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeFilesystem userInfo:@{NSLocalizedDescriptionKey : directoryError.localizedDescription ?: @"Unable to prepare download directory."}];
+        [self finishWithError:error];
+        return;
+    }
+
+    if (fileURLs.count == 0) {
+        [self updateStatus:@"No media listed in manifest." preview:nil];
+        [self finishWithError:nil];
+        return;
+    }
+
+    [self downloadFiles:fileURLs toDirectory:mediaDirectoryURL atIndex:0 latestPreview:nil];
+}
+
+- (void)downloadFiles:(NSArray<NSURL *> *)fileURLs toDirectory:(NSURL *)directoryURL atIndex:(NSUInteger)index latestPreview:(UIImage * _Nullable)latestPreview {
+    if (index >= fileURLs.count) {
+        [self updateStatus:@"All media downloaded." preview:latestPreview];
+        [self finishWithError:nil];
+        return;
+    }
+
+    NSURL *fileURL = fileURLs[index];
+    NSString *filename = fileURL.lastPathComponent.length > 0 ? fileURL.lastPathComponent : [NSString stringWithFormat:@"media_%lu", (unsigned long)index];
+    NSURL *destinationURL = [directoryURL URLByAppendingPathComponent:filename];
+
+    [self updateStatus:[NSString stringWithFormat:@"Downloading %lu/%lu: %@", (unsigned long)(index + 1), (unsigned long)fileURLs.count, filename] preview:latestPreview];
+
+    __weak typeof(self) weakSelf = self;
+    NSURLSessionDataTask *task = [self.session dataTaskWithURL:fileURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (error) {
+            NSString *description = [NSString stringWithFormat:@"Failed to download %@: %@", filename, error.localizedDescription ?: @"unknown error"];
+            NSError *downloadError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeDownload userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:downloadError];
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            NSString *description = [NSString stringWithFormat:@"Failed to download %@: HTTP %ld", filename, (long)httpResponse.statusCode];
+            NSError *downloadError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeDownload userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:downloadError];
+            return;
+        }
+
+        if (data.length == 0) {
+            NSString *description = [NSString stringWithFormat:@"%@ is empty.", filename];
+            NSError *downloadError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeDownload userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:downloadError];
+            return;
+        }
+
+        [[NSFileManager defaultManager] removeItemAtURL:destinationURL error:nil];
+        NSError *writeError = nil;
+        if (![data writeToURL:destinationURL options:NSDataWritingAtomic error:&writeError]) {
+            NSString *description = [NSString stringWithFormat:@"Failed to save %@: %@", filename, writeError.localizedDescription ?: @"unknown error"];
+            NSError *filesystemError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeFilesystem userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:filesystemError];
+            return;
+        }
+
+        UIImage *previewImage = [strongSelf previewImageForData:data];
+        UIImage *nextPreview = previewImage ?: latestPreview;
+        NSString *status = [NSString stringWithFormat:@"Saved %@", filename];
+        [strongSelf updateStatus:status preview:nextPreview];
+        [strongSelf downloadFiles:fileURLs toDirectory:directoryURL atIndex:index + 1 latestPreview:nextPreview];
+    }];
+    [task resume];
+}
+
+#pragma mark - Helpers
+
+- (UIImage * _Nullable)previewImageForData:(NSData *)data {
+    UIImage *image = [UIImage imageWithData:data scale:UIScreen.mainScreen.scale];
+    return image;
+}
+
+- (void)updateStatus:(NSString *)status preview:(UIImage * _Nullable)preview {
+    if (!self.statusHandler) { return; }
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.statusHandler(status, preview);
+    });
+}
+
+- (void)finishWithError:(NSError * _Nullable)error {
+    if (self.didFinish) { return; }
+    self.didFinish = YES;
+    GlassesMediaDownloaderCompletionHandler completion = self.completionHandler;
+    if (completion) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(error);
+        });
+    }
+    self.completionHandler = nil;
+}
+
+@end

--- a/ios/QCSDKDemo/GlassesMediaDownloader.m
+++ b/ios/QCSDKDemo/GlassesMediaDownloader.m
@@ -2,6 +2,7 @@
 
 #import <QCSDK/QCSDKCmdCreator.h>
 #import <NetworkExtension/NetworkExtension.h>
+#import <SystemConfiguration/CaptiveNetwork.h>
 
 static NSString * const GlassesMediaDownloaderErrorDomain = @"GlassesMediaDownloaderErrorDomain";
 
@@ -22,6 +23,7 @@ typedef NS_ENUM(NSInteger, GlassesMediaDownloaderErrorCode) {
 @property (nonatomic, copy) NSString *deviceIP;
 @property (nonatomic, strong) NSURLSession *session;
 @property (nonatomic, assign) BOOL didFinish;
+@property (nonatomic, assign) BOOL isRequestingWifiCredentials;
 @end
 
 @implementation GlassesMediaDownloader
@@ -31,6 +33,7 @@ typedef NS_ENUM(NSInteger, GlassesMediaDownloaderErrorCode) {
     if (self) {
         _statusHandler = [statusHandler copy];
         _session = [NSURLSession sessionWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration];
+        _isRequestingWifiCredentials = NO;
     }
     return self;
 }
@@ -45,75 +48,956 @@ typedef NS_ENUM(NSInteger, GlassesMediaDownloaderErrorCode) {
 #pragma mark - Flow
 
 - (void)requestWifiCredentials {
+    // Prevent duplicate requests
+    if (self.isRequestingWifiCredentials) {
+        NSLog(@"🔥 WiFi credentials already being requested, skipping duplicate");
+        return;
+    }
+
+    self.isRequestingWifiCredentials = YES;
     __weak typeof(self) weakSelf = self;
+    NSLog(@"🔥 requestWifiCredentials called - trying to enable WiFi transfer mode");
+
+    // First try to enable WiFi transfer mode on the device
     [QCSDKCmdCreator openWifiWithMode:QCOperatorDeviceModeTransfer success:^(NSString *ssid, NSString *password) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
         strongSelf.ssid = ssid ?: @"";
         strongSelf.password = password ?: @"";
-        [strongSelf updateStatus:[NSString stringWithFormat:@"Received hotspot: %@", ssid ?: @"<unknown>"] preview:nil];
-        [strongSelf requestDeviceIP];
+        strongSelf.isRequestingWifiCredentials = NO;
+        NSLog(@"🔥 Got WiFi credentials from device - SSID: %@", ssid);
+        [strongSelf updateStatus:[NSString stringWithFormat:@"Got hotspot: %@", ssid ?: @"<unknown>"] preview:nil];
+
+        // First try to get device IP - if that works, we don't need to join hotspot
+        [strongSelf tryGetDeviceIPFirst];
     } fail:^(NSInteger code) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
-        NSString *description = [NSString stringWithFormat:@"Failed to request Wi-Fi credentials (code %ld).", (long)code];
-        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiCredentials userInfo:@{NSLocalizedDescriptionKey : description}];
-        [strongSelf finishWithError:error];
+        strongSelf.isRequestingWifiCredentials = NO;
+        NSLog(@"🔥 Failed to get WiFi credentials from device, code: %ld", (long)code);
+
+        // Try to prompt for manual hotspot connection
+        [strongSelf promptForManualHotspot];
     }];
+}
+
+- (void)tryGetDeviceIPFirst {
+    __weak typeof(self) weakSelf = self;
+    NSLog(@"🔥 Got credentials, checking current connection");
+    [self updateStatus:[NSString stringWithFormat:@"WiFi: %@ (tap to join)", self.ssid] preview:nil];
+
+    // Try to connect immediately if possible, otherwise prompt user
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __strong typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        [strongSelf tryQuickConnection];
+    });
+}
+
+- (void)tryQuickConnection {
+    NSLog(@"🔥 Attempting quick connection test");
+    [self updateStatus:@"Testing connection..." preview:nil];
+
+    // Try to get device IP immediately - this will work if already on same network
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        if (ipAddress.length > 0) {
+            NSLog(@"🔥 Quick connection successful - IP: %@", ipAddress);
+            [self updateStatus:[NSString stringWithFormat:@"Found device at %@", ipAddress] preview:nil];
+            [self testConnectionToIP:ipAddress];
+        } else {
+            NSLog(@"🔥 Quick connection failed - trying hotspot configuration");
+            [self tryHotspotConfiguration];
+        }
+    } failed:^{
+        NSLog(@"🔥 Quick connection failed - trying hotspot configuration");
+        [self tryHotspotConfiguration];
+    }];
+}
+
+- (void)tryHotspotConfiguration {
+    NSLog(@"🔥 Trying hotspot configuration - PERSISTENT approach");
+    [self updateStatus:@"Configuring WiFi automatically..." preview:nil];
+
+    if (@available(iOS 11.0, *)) {
+        [self joinHotspotWithAggressiveConfig];
+    } else {
+        [self showManualConnectionInstructions];
+    }
+}
+
+- (void)joinHotspotWithAggressiveConfig {
+    if (@available(iOS 11.0, *)) {
+        NSLog(@"🔥 joinHotspotWithAggressiveConfig called with SSID: %@", self.ssid);
+
+        // Create aggressive configuration - multiple attempts with different settings
+        [self attemptHotspotConfigurationWithJoinOnce:NO attempt:1];
+    }
+}
+
+- (void)attemptHotspotConfigurationWithJoinOnce:(BOOL)joinOnce attempt:(NSInteger)attempt {
+    if (@available(iOS 11.0, *)) {
+        NSLog(@"🔥 Attempt %ld: joinOnce=%d for SSID: %@", (long)attempt, joinOnce, self.ssid);
+
+        NEHotspotConfiguration *configuration = nil;
+
+        if (self.password.length > 0) {
+            configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid
+                                                               passphrase:self.password
+                                                                   isWEP:NO];
+        } else {
+            configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid];
+        }
+
+        // Aggressive configuration options
+        configuration.joinOnce = joinOnce;
+        if (@available(iOS 13.0, *)) {
+            configuration.lifeTimeInDays = @1;
+        }
+
+        __weak typeof(self) weakSelf = self;
+
+        [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration
+                                                     completionHandler:^(NSError * _Nullable error) {
+            __strong typeof(weakSelf) strongSelf = weakSelf;
+            if (!strongSelf) { return; }
+
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (!error) {
+                    NSLog(@"🔥 SUCCESS: Applied hotspot configuration (attempt %ld)", (long)attempt);
+                    [strongSelf updateStatus:@"WiFi configured! Waiting for connection..." preview:nil];
+
+                    // Wait for connection - LONGER time like working apps
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(12.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        [strongSelf testConnectionAfterAggressiveJoin];
+                    });
+                } else if (error.code == NEHotspotConfigurationErrorAlreadyAssociated) {
+                    NSLog(@"🔥 Already associated - testing connection");
+                    [strongSelf updateStatus:@"Already connected! Testing..." preview:nil];
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        [strongSelf testConnectionAfterAggressiveJoin];
+                    });
+                } else if (attempt < 3) {
+                    NSLog(@"🔥 Attempt %ld failed, retrying with different settings: %@", (long)attempt, error.localizedDescription);
+                    [strongSelf attemptHotspotConfigurationWithJoinOnce:!joinOnce attempt:attempt + 1];
+                } else {
+                    NSLog(@"🔥 All hotspot attempts failed: %@", error.localizedDescription);
+                    [strongSelf updateStatus:@"Auto WiFi failed. Manual connection needed." preview:nil];
+
+                    // Wait before showing manual instructions
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        [strongSelf showManualConnectionInstructions];
+                    });
+                }
+            });
+        }];
+    }
+}
+
+- (void)testConnectionAfterAggressiveJoin {
+    NSLog(@"🔥 Testing connection after AGGRESSIVE hotspot join");
+    [self updateStatus:@"Testing WiFi connection..." preview:nil];
+
+    // Aggressive connection testing like working apps
+    [self testConnectionWithIncreasingTimeouts];
+}
+
+- (void)testConnectionWithIncreasingTimeouts {
+    NSLog(@"🔥 Starting aggressive connection testing");
+
+    // Try multiple approaches with increasing timeouts
+    [self tryGetDeviceIPWithTimeout:5.0 attempt:1];
+}
+
+- (void)tryGetDeviceIPWithTimeout:(NSTimeInterval)timeout attempt:(NSInteger)attempt {
+    NSLog(@"🔥 Getting device IP with timeout %.1f, attempt %ld", timeout, (long)attempt);
+
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        if (ipAddress.length > 0) {
+            NSLog(@"🔥 Got device IP: %@", ipAddress);
+            [self updateStatus:[NSString stringWithFormat:@"Found device! Testing connection to %@", ipAddress] preview:nil];
+            [self testConnectionToIPWithTimeout:ipAddress timeout:timeout];
+        } else if (attempt < 3) {
+            NSLog(@"🔥 No IP on attempt %ld, retrying with longer timeout", (long)attempt);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [self tryGetDeviceIPWithTimeout:timeout + 3.0 attempt:attempt + 1];
+            });
+        } else {
+            NSLog(@"🔥 No device IP after multiple attempts");
+            [self testConnectionWithCommonIPs];
+        }
+    } failed:^{
+        if (attempt < 3) {
+            NSLog(@"🔥 QCSDK failed on attempt %ld, retrying", (long)attempt);
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                [self tryGetDeviceIPWithTimeout:timeout + 3.0 attempt:attempt + 1];
+            });
+        } else {
+            NSLog(@"🔥 QCSDK failed after multiple attempts");
+            [self testConnectionWithCommonIPs];
+        }
+    }];
+}
+
+- (void)testConnectionToIPWithTimeout:(NSString *)ip timeout:(NSTimeInterval)timeout {
+    NSLog(@"🔥 Testing connection to %@ with timeout %.1f", ip, timeout);
+
+    [self updateStatus:[NSString stringWithFormat:@"Testing connection to %@...", ip] preview:nil];
+
+    // Use shorter timeout for initial test, but with retry logic
+    NSTimeInterval adjustedTimeout = (timeout > 5.0) ? 3.0 : timeout;
+    NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                            cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                        timeoutInterval:adjustedTimeout];
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request
+                                                                 completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                NSLog(@"🔥 SUCCESS: Connected to device at %@", ip);
+                [self updateStatus:[NSString stringWithFormat:@"✅ CONNECTED to %@", ip] preview:nil];
+                // Set deviceIP BEFORE proceeding to download manifest
+                self->_deviceIP = ip;
+                // Verify WiFi connection is established before downloading
+                [self verifyWiFiConnectionAndProceed];
+            } else {
+                NSLog(@"🔥 Failed to connect to %@: %@", ip, error.localizedDescription);
+                // If this was the original IP from QCSDK, try it once more with longer timeout
+                if ([ip isEqualToString:@"3.192.168.31"] && timeout <= 5.0) {
+                    NSLog(@"🔥 Retrying original IP with longer timeout...");
+                    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                        [self testConnectionToIPWithTimeout:ip timeout:8.0];
+                    });
+                } else {
+                    [self testConnectionWithCommonIPs];
+                }
+            }
+        });
+    }];
+    [task resume];
+}
+
+- (void)verifyWiFiConnectionAndProceed {
+    NSLog(@"🔥 Verifying WiFi connection is stable before proceeding");
+    [self updateStatus:@"Verifying WiFi connection..." preview:nil];
+
+    // Test connectivity multiple times to ensure stable connection
+    [self testConnectivityWithRetries:3 attempt:1];
+}
+
+- (void)testConnectivityWithRetries:(NSInteger)maxRetries attempt:(NSInteger)attempt {
+    if (self->_deviceIP.length == 0) {
+        NSLog(@"🔥 ERROR: No device IP set for connectivity test");
+        [self testConnectionWithCommonIPs];
+        return;
+    }
+
+    NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", self->_deviceIP]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                            cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                        timeoutInterval:2.0]; // Reduced from 3.0
+
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                NSLog(@"🔥 WiFi connection verified successfully (attempt %ld)", (long)attempt);
+                [self updateStatus:[NSString stringWithFormat:@"✅ WiFi stable at %@", self->_deviceIP] preview:nil];
+                // Now proceed with endpoint discovery
+                [self discoverAllEndpointsForIP:self->_deviceIP];
+            } else if (attempt < maxRetries) {
+                NSLog(@"🔥 WiFi test failed on attempt %ld, retrying...", (long)attempt);
+                [self updateStatus:[NSString stringWithFormat:@"Testing connection... (attempt %ld)", (long)attempt] preview:nil];
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{ // Reduced from 2.0
+                    [self testConnectivityWithRetries:maxRetries attempt:attempt + 1];
+                });
+            } else {
+                NSLog(@"🔥 WiFi connection test failed after %ld attempts", (long)attempt);
+                [self updateStatus:@"WiFi connection unstable" preview:nil];
+                [self testConnectionWithCommonIPs];
+            }
+        });
+    }] resume];
+}
+
+- (void)testConnectionAfterEnhancedHotspotJoin {
+    NSLog(@"🔥 Testing connection after enhanced hotspot join");
+    [self updateStatus:@"Testing enhanced connection..." preview:nil];
+
+    // Check network connectivity with multiple approaches
+    [self checkNetworkConnectivityWithCompletion:^(BOOL isConnected) {
+        if (isConnected) {
+            NSLog(@"🔥 Network connectivity confirmed, trying device connection");
+            [self tryFinalConnectionTest];
+        } else {
+            NSLog(@"🔥 No network connectivity, falling back to manual instructions");
+            [self showManualConnectionInstructions];
+        }
+    }];
+}
+
+- (void)checkNetworkConnectivityWithCompletion:(void (^)(BOOL))completion {
+    // Test internet connectivity by trying to reach apple.com
+    NSURL *testURL = [NSURL URLWithString:@"http://captive.apple.com"];
+    NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                            cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                        timeoutInterval:3.0];
+
+    [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+        BOOL canReachInternet = !error && ((NSHTTPURLResponse *)response).statusCode == 200;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completion(canReachInternet);
+        });
+    }] resume];
+}
+
+- (void)tryFinalConnectionTest {
+    NSLog(@"🔥 Final connection test attempt");
+    [self updateStatus:@"Final connection test..." preview:nil];
+
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        if (ipAddress.length > 0) {
+            [self testConnectionToIP:ipAddress];
+        } else {
+            [self showManualConnectionInstructions];
+        }
+    } failed:^{
+        [self showManualConnectionInstructions];
+    }];
+}
+
+- (void)showManualConnectionInstructions {
+    NSLog(@"🔥 Showing enhanced manual connection instructions");
+    NSString *instructions = [NSString stringWithFormat:@"📶 MANUALLY join WiFi:\n%@\n\n👆 Then wait for connection...", self.ssid];
+    [self updateStatus:instructions preview:nil];
+
+    // Try connection after giving user more time to manually connect
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(20.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self tryConnectionAfterManualPrompt];
+    });
+}
+
+- (void)tryConnectionAfterManualPrompt {
+    NSLog(@"🔥 Testing connection after manual prompt");
+    [self updateStatus:@"Testing manual connection..." preview:nil];
+
+    // First check if we can get device IP through QCSDK
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        if (ipAddress.length > 0) {
+            NSLog(@"🔥 Got device IP after manual prompt: %@", ipAddress);
+            [self updateStatus:[NSString stringWithFormat:@"Found device at %@", ipAddress] preview:nil];
+            [self testConnectionToIP:ipAddress];
+        } else {
+            NSLog(@"🔥 No IP from QCSDK, trying comprehensive IP scan");
+            [self performComprehensiveIPScan];
+        }
+    } failed:^{
+        NSLog(@"🔥 QCSDK failed, trying comprehensive IP scan");
+        [self performComprehensiveIPScan];
+    }];
+}
+
+- (void)performComprehensiveIPScan {
+    [self updateStatus:@"Scanning for glasses device..." preview:nil];
+
+    // Expanded list of common glasses IPs
+    NSArray *comprehensiveIPs = @[
+        @"192.168.43.1", @"192.168.4.1", @"192.168.1.1", @"192.168.0.1",
+        @"192.168.31.1", @"192.168.100.1", @"192.168.123.1", @"192.168.137.1",
+        @"3.192.168.31", @"10.0.0.1", @"172.20.10.1"
+    ];
+
+    __block NSString *workingIP = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    NSLog(@"🔥 Starting comprehensive IP scan with %lu IPs", (unsigned long)comprehensiveIPs.count);
+
+    for (NSString *ip in comprehensiveIPs) {
+        NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                                cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                            timeoutInterval:2.0];
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                workingIP = ip;
+                NSLog(@"🔥 Found working IP: %@", ip);
+            }
+            dispatch_semaphore_signal(semaphore);
+        }] resume];
+
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.5 * NSEC_PER_SEC)));
+        if (workingIP) break;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (workingIP) {
+            self->_deviceIP = workingIP;
+            [self updateStatus:[NSString stringWithFormat:@"✅ Connected to glasses at %@", workingIP] preview:nil];
+            // Verify WiFi connection before proceeding to manifest download
+            [self verifyWiFiConnectionAndProceed];
+        } else {
+            [self showFinalErrorMessage];
+        }
+    });
+}
+
+- (void)showFinalErrorMessage {
+    NSString *errorMessage = [NSString stringWithFormat:@"❌ Connection failed!\n\n1. 📶 Join WiFi: %@\n2. 🔋 Ensure glasses are ON\n3. 🔄 Try restarting app\n\nNote: Auto WiFi doesn't work reliably on iOS 18+", self.ssid];
+    [self updateStatus:errorMessage preview:nil];
+
+    NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain
+                                         code:GlassesMediaDownloaderErrorCodeWifiIP
+                                     userInfo:@{NSLocalizedDescriptionKey : @"Could not establish connection to glasses device. Please check WiFi connection and try again."}];
+    [self finishWithError:error];
+}
+
+- (void)promptForManualHotspot {
+    [self updateStatus:@"Please connect to glasses WiFi hotspot (AM01W_XXXX) manually" preview:nil];
+
+    // Try common glasses SSIDs after user has time to connect manually
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(10.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        __weak typeof(self) weakSelf = self;
+        [self tryCommonGlassesIPs];
+    });
+}
+
+- (void)tryCommonGlassesIPs {
+    [self updateStatus:@"Looking for glasses on network..." preview:nil];
+
+    // Try common glasses IPs to find the device
+    NSArray *commonIPs = @[@"192.168.1.1", @"192.168.0.1", @"192.168.43.1", @"192.168.4.1", @"192.168.31.1"];
+
+    __block NSString *workingIP = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    for (NSString *ip in commonIPs) {
+        NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:testURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:2.0];
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                workingIP = ip;
+            }
+            dispatch_semaphore_signal(semaphore);
+        }] resume];
+
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)));
+        if (workingIP) break;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (workingIP) {
+            self->_deviceIP = workingIP;
+            [self updateStatus:[NSString stringWithFormat:@"Found glasses at %@", workingIP] preview:nil];
+            // Verify WiFi connection before proceeding to manifest download
+            [self verifyWiFiConnectionAndProceed];
+        } else {
+            NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Could not find glasses. Please ensure you're connected to the glasses WiFi hotspot."}];
+            [self finishWithError:error];
+        }
+    });
 }
 
 - (void)requestDeviceIP {
     __weak typeof(self) weakSelf = self;
+    NSLog(@"🔥 requestDeviceIP called after hotspot join");
     [self updateStatus:@"Retrieving device IP address..." preview:nil];
     [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
+        NSLog(@"🔥 Got IP address: %@", ipAddress ?: @"nil");
         if (ipAddress.length == 0) {
-            NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Device did not report a Wi-Fi IP address."}];
-            [strongSelf finishWithError:error];
+            NSLog(@"🔥 IP address is empty, testing connection manually");
+            [strongSelf testConnectionWithCommonIPs];
             return;
         }
-        strongSelf.deviceIP = ipAddress;
-        [strongSelf joinHotspot];
+        NSLog(@"🔥 Setting device IP to: %@", ipAddress);
+        strongSelf->_deviceIP = ipAddress;
+        [strongSelf updateStatus:[NSString stringWithFormat:@"Found device at %@", ipAddress] preview:nil];
+
+        // Actually test if we can reach this IP
+        [strongSelf testConnectionToIP:ipAddress];
     } failed:^{
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
-        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Failed to retrieve device Wi-Fi IP address."}];
-        [strongSelf finishWithError:error];
+        NSLog(@"🔥 Failed to get device IP, testing common IPs");
+        [strongSelf testConnectionWithCommonIPs];
     }];
 }
 
-- (void)joinHotspot {
-    [self updateStatus:@"Joining device hotspot..." preview:nil];
+- (void)testConnectionToIP:(NSString *)ip {
+    [self updateStatus:[NSString stringWithFormat:@"Testing connection to %@...", ip] preview:nil];
+
+    NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+    NSURLRequest *request = [NSURLRequest requestWithURL:testURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:5.0];
+
+    NSURLSessionDataTask *task = [[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                NSLog(@"🔥 Successfully connected to %@", ip);
+                [self updateStatus:[NSString stringWithFormat:@"Connected to %@", ip] preview:nil];
+                // Set deviceIP and verify connection before proceeding
+                self->_deviceIP = ip;
+                [self verifyWiFiConnectionAndProceed];
+            } else {
+                NSLog(@"🔥 Failed to connect to %@: %@", ip, error.localizedDescription);
+                [self testConnectionWithCommonIPs];
+            }
+        });
+    }];
+    [task resume];
+}
+
+- (void)testConnectionWithCommonIPs {
+    [self updateStatus:@"🔍 Scanning for glasses endpoints..." preview:nil];
+
+    // Prioritized IP list - try most likely ones first
+    NSArray *priorityIPs = @[@"192.168.31.1", @"3.192.168.31", @"192.168.43.1", @"192.168.4.1"];
+    NSArray *fallbackIPs = @[@"192.168.1.1", @"192.168.0.1"];
+
+    __block NSString *workingIP = nil;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    NSLog(@"🔥 Starting fast IP scan with priority IPs first");
+
+    // Test priority IPs first with shorter timeout
+    for (NSString *ip in priorityIPs) {
+        NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:testURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:1.5];
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                workingIP = ip;
+                NSLog(@"🔥 Found working priority IP: %@", ip);
+            }
+            dispatch_semaphore_signal(semaphore);
+        }] resume];
+
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)));
+        if (workingIP) break;
+    }
+
+    // If no priority IPs worked, try fallbacks
+    if (!workingIP) {
+        NSLog(@"🔥 No priority IPs worked, trying fallbacks");
+        for (NSString *ip in fallbackIPs) {
+            NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+            NSURLRequest *request = [NSURLRequest requestWithURL:testURL cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:1.0];
+
+            [[[NSURLSession sharedSession] dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (!error && data && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                    workingIP = ip;
+                    NSLog(@"🔥 Found working fallback IP: %@", ip);
+                }
+                dispatch_semaphore_signal(semaphore);
+            }] resume];
+
+            dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)));
+            if (workingIP) break;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (workingIP) {
+            self->_deviceIP = workingIP;
+            [self updateStatus:[NSString stringWithFormat:@"✅ Found glasses at %@", workingIP] preview:nil];
+            NSLog(@"🔥 Successfully connected to glasses at IP: %@", workingIP);
+            // Verify WiFi connection before proceeding to endpoint discovery
+            [self verifyWiFiConnectionAndProceed];
+        } else {
+            NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeWifiIP userInfo:@{NSLocalizedDescriptionKey : @"Could not reach glasses. Please manually connect to the glasses WiFi hotspot."}];
+            [self finishWithError:error];
+        }
+    });
+}
+
+- (void)discoverAllEndpointsForIP:(NSString *)ip {
+    NSLog(@"🔥 Starting fast endpoint discovery for IP: %@", ip);
+    [self updateStatus:[NSString stringWithFormat:@"🔍 Discovering endpoints on %@...", ip] preview:nil];
+
+    // Prioritized list - test most likely endpoints first
+    NSArray *priorityEndpoints = @[
+        @"/files/media.config",
+        @"/media.config",
+        @"/files/manifest",
+        @"/manifest"
+    ];
+
+    // Secondary endpoints to test if priority ones fail
+    NSArray *secondaryEndpoints = @[
+        @"/api/media",
+        @"/api/files",
+        @"/config",
+        @"/files",
+        @"/"
+    ];
+
+    NSMutableArray *foundEndpoints = [NSMutableArray array];
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    NSLog(@"🔥 Testing priority endpoints first on IP %@", ip);
+
+    // Test priority endpoints first with shorter timeout
+    for (NSString *endpoint in priorityEndpoints) {
+        NSString *urlString = [NSString stringWithFormat:@"http://%@%@", ip, endpoint];
+        NSURL *testURL = [NSURL URLWithString:urlString];
+        NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                                cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                            timeoutInterval:1.5]; // Reduced from 3.0
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error) {
+                NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                NSLog(@"🔥 PRIORITY ENDPOINT: %@ - Status: %ld", urlString, (long)httpResponse.statusCode);
+
+                if (httpResponse.statusCode == 200 && data.length > 0) {
+                    [foundEndpoints addObject:@{
+                        @"url": urlString,
+                        @"endpoint": endpoint,
+                        @"status": @(httpResponse.statusCode),
+                        @"contentLength": @(data.length),
+                        @"contentType": httpResponse.MIMEType ?: @"unknown"
+                    }];
+                    NSLog(@"🔥 ✅ VALID PRIORITY ENDPOINT: %@", urlString);
+                }
+            }
+            dispatch_semaphore_signal(semaphore);
+        }] resume];
+
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC))); // Reduced from 3.5
+
+        // If we found the main endpoint, break early
+        if (foundEndpoints.count > 0) {
+            NSLog(@"🔥 Found priority endpoint, skipping secondary scan");
+            break;
+        }
+    }
+
+    // If no priority endpoints found, test secondary ones
+    if (foundEndpoints.count == 0) {
+        NSLog(@"🔥 No priority endpoints found, testing secondary ones");
+
+        for (NSString *endpoint in secondaryEndpoints) {
+            NSString *urlString = [NSString stringWithFormat:@"http://%@%@", ip, endpoint];
+            NSURL *testURL = [NSURL URLWithString:urlString];
+            NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                                    cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                                timeoutInterval:1.0];
+
+            [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+                if (!error) {
+                    NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                    if (httpResponse.statusCode == 200 && data.length > 0) {
+                        [foundEndpoints addObject:@{
+                            @"url": urlString,
+                            @"endpoint": endpoint,
+                            @"status": @(httpResponse.statusCode),
+                            @"contentLength": @(data.length),
+                            @"contentType": httpResponse.MIMEType ?: @"unknown"
+                        }];
+                        NSLog(@"🔥 ✅ VALID SECONDARY ENDPOINT: %@", urlString);
+                    }
+                }
+                dispatch_semaphore_signal(semaphore);
+            }] resume];
+
+            dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)));
+
+            // If we found an endpoint, break early
+            if (foundEndpoints.count > 0) break;
+        }
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSLog(@"🔥 Fast endpoint discovery complete. Found %lu valid endpoints.", (unsigned long)foundEndpoints.count);
+
+        // Log all found endpoints
+        for (NSDictionary *endpointInfo in foundEndpoints) {
+            NSLog(@"🔥 📄 Found: %@ (%@ bytes, %@)",
+                  endpointInfo[@"url"],
+                  endpointInfo[@"contentLength"],
+                  endpointInfo[@"contentType"]);
+        }
+
+        if (foundEndpoints.count > 0) {
+            [self updateStatus:[NSString stringWithFormat:@"🔍 Found %lu endpoints!", (unsigned long)foundEndpoints.count] preview:nil];
+            [self processDiscoveredEndpoints:foundEndpoints];
+        } else {
+            [self updateStatus:@"No media endpoints found" preview:nil];
+            NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"No media endpoints found on glasses device."}];
+            [self finishWithError:error];
+        }
+    });
+}
+
+- (void)processDiscoveredEndpoints:(NSArray *)foundEndpoints {
+    NSLog(@"🔥 Processing %lu discovered endpoints", (unsigned long)foundEndpoints.count);
+
+    // Priority order for endpoints
+    NSArray *priorityEndpoints = @[
+        @"/files/media.config",
+        @"/media.config",
+        @"/files/manifest",
+        @"/manifest",
+        @"/api/media"
+    ];
+
+    // Try priority endpoints first
+    for (NSString *priorityEndpoint in priorityEndpoints) {
+        for (NSDictionary *endpointInfo in foundEndpoints) {
+            if ([endpointInfo[@"endpoint"] isEqualToString:priorityEndpoint]) {
+                NSLog(@"🔥 🎯 Using priority endpoint: %@", endpointInfo[@"url"]);
+                [self useDiscoveredEndpoint:endpointInfo];
+                return;
+            }
+        }
+    }
+
+    // If no priority endpoints, use the first one found
+    if (foundEndpoints.count > 0) {
+        NSDictionary *firstEndpoint = foundEndpoints[0];
+        NSLog(@"🔥 📋 Using first available endpoint: %@", firstEndpoint[@"url"]);
+        [self useDiscoveredEndpoint:firstEndpoint];
+    }
+}
+
+- (void)useDiscoveredEndpoint:(NSDictionary *)endpointInfo {
+    NSString *urlString = endpointInfo[@"url"];
+    NSNumber *contentLength = endpointInfo[@"contentLength"];
+    NSString *contentType = endpointInfo[@"contentType"];
+
+    NSLog(@"🔥 Using endpoint: %@ (Size: %@ bytes, Type: %@)", urlString, contentLength, contentType);
+
+    // Check if this is a manifest/config file
+    NSString *endpoint = endpointInfo[@"endpoint"];
+    if ([endpoint containsString:@"media.config"] || [endpoint containsString:@"manifest"] || [endpoint containsString:@"config"]) {
+        NSLog(@"🔥 Treating as manifest endpoint: %@", urlString);
+        self.deviceIP = [self extractIPFromURL:urlString];
+        [self updateStatus:[NSString stringWithFormat:@"📄 Loading manifest from %@", endpoint] preview:nil];
+        [self downloadManifestFromCustomURL:urlString];
+    } else {
+        NSLog(@"🔥 Treating as direct media endpoint: %@", urlString);
+        [self updateStatus:[NSString stringWithFormat:@"🎥 Direct media access: %@", endpoint] preview:nil];
+        [self downloadDirectMediaFromURL:urlString];
+    }
+}
+
+- (NSString *)extractIPFromURL:(NSString *)urlString {
+    NSURL *url = [NSURL URLWithString:urlString];
+    return url.host;
+}
+
+- (void)downloadManifestFromCustomURL:(NSString *)manifestURLString {
+    NSLog(@"🔥 Downloading manifest from custom URL: %@", manifestURLString);
+
+    NSURL *manifestURL = [NSURL URLWithString:manifestURLString];
+    if (!manifestURL) {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"Invalid manifest URL."}];
+        [self finishWithError:error];
+        return;
+    }
+
+    [self updateStatus:@"Fetching custom media manifest..." preview:nil];
+    __weak typeof(self) weakSelf = self;
+    NSURLSessionDataTask *task = [self.session dataTaskWithURL:manifestURL completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+
+        if (error) {
+            NSString *description = [NSString stringWithFormat:@"Failed to download manifest: %@", error.localizedDescription ?: @"unknown error"];
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        if (httpResponse.statusCode < 200 || httpResponse.statusCode >= 300) {
+            NSString *description = [NSString stringWithFormat:@"Manifest request returned HTTP %ld.", (long)httpResponse.statusCode];
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : description}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSLog(@"🔥 ✅ Manifest downloaded successfully! Size: %llu bytes", httpResponse.expectedContentLength);
+
+        NSString *configString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        if (!configString) {
+            configString = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
+        }
+
+        NSLog(@"🔥 📄 Manifest content: %@", configString.length > 200 ? [configString substringToIndex:200] : configString);
+
+        if (configString.length == 0) {
+            NSError *manifestError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"Media manifest is empty."}];
+            [strongSelf finishWithError:manifestError];
+            return;
+        }
+
+        NSArray<NSURL *> *fileURLs = [strongSelf fileURLsFromManifestString:configString baseURL:manifestURL];
+        NSLog(@"🔥 📁 Found %lu media files in manifest", (unsigned long)fileURLs.count);
+
+        [strongSelf prepareDownloadDirectoryWithManifest:fileURLs baseURL:manifestURL];
+    }];
+    [task resume];
+}
+
+- (void)downloadDirectMediaFromURL:(NSString *)mediaURLString {
+    NSLog(@"🔥 Downloading direct media from: %@", mediaURLString);
+
+    NSURL *mediaURL = [NSURL URLWithString:mediaURLString];
+    if (!mediaURL) {
+        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeDownload userInfo:@{NSLocalizedDescriptionKey : @"Invalid media URL."}];
+        [self finishWithError:error];
+        return;
+    }
+
+    NSString *filename = mediaURL.lastPathComponent.length > 0 ? mediaURL.lastPathComponent : @"media_file";
+    [self updateStatus:[NSString stringWithFormat:@"Downloading: %@", filename] preview:nil];
+
+    // Create a single-file manifest for direct download
+    NSArray<NSURL *> *singleFileArray = @[mediaURL];
+    NSURL *baseURL = [mediaURL URLByDeletingLastPathComponent];
+
+    [self prepareDownloadDirectoryWithManifest:singleFileArray baseURL:baseURL];
+}
+
+
+- (void)joinHotspotWithModernConfig {
+    NSLog(@"🔥 joinHotspotWithModernConfig called with SSID: %@, password: %@", self.ssid, self.password);
+    [self updateStatus:@"Configuring WiFi connection..." preview:nil];
+
     if (@available(iOS 11.0, *)) {
         NEHotspotConfiguration *configuration = nil;
+
+        // Modern iOS configuration
         if (self.password.length > 0) {
             configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid passphrase:self.password isWEP:NO];
         } else {
             configuration = [[NEHotspotConfiguration alloc] initWithSSID:self.ssid];
         }
-        configuration.joinOnce = YES;
+
+        // Modern configuration options
+        configuration.joinOnce = YES;  // Join once for this session
+
+        NSLog(@"🔥 Applying modern NEHotspotConfiguration for SSID: %@", self.ssid);
         __weak typeof(self) weakSelf = self;
+
         [[NEHotspotConfigurationManager sharedManager] applyConfiguration:configuration completionHandler:^(NSError * _Nullable error) {
             __strong typeof(weakSelf) strongSelf = weakSelf;
             if (!strongSelf) { return; }
-            if (!error || error.code == NEHotspotConfigurationErrorAlreadyAssociated) {
-                [strongSelf updateStatus:@"Connected to device hotspot." preview:nil];
-                [strongSelf downloadManifest];
+
+            if (!error) {
+                NSLog(@"🔥 Successfully applied hotspot configuration!");
+                [strongSelf updateStatus:@"WiFi configured. Testing connection..." preview:nil];
+
+                // Wait a moment for connection to establish
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [strongSelf testConnectionAfterHotspotJoin];
+                });
+            } else if (error.code == NEHotspotConfigurationErrorAlreadyAssociated) {
+                NSLog(@"🔥 Already associated with hotspot");
+                [strongSelf updateStatus:@"Already connected. Testing connection..." preview:nil];
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [strongSelf testConnectionAfterHotspotJoin];
+                });
             } else {
-                NSString *description = [NSString stringWithFormat:@"Unable to join hotspot (%@).", error.localizedDescription ?: @"unknown error"];
-                NSError *joinError = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeHotspotUnavailable userInfo:@{NSLocalizedDescriptionKey : description}];
-                [strongSelf finishWithError:joinError];
+                NSLog(@"🔥 Failed to configure hotspot: %@", error.localizedDescription);
+                [strongSelf updateStatus:[NSString stringWithFormat:@"WiFi config failed: %@", error.localizedDescription] preview:nil];
+
+                // Fallback to manual connection prompt
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                    [strongSelf promptForManualConnection];
+                });
             }
         }];
     } else {
-        NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeHotspotUnavailable userInfo:@{NSLocalizedDescriptionKey : @"Hotspot configuration requires iOS 11 or later."}];
-        [self finishWithError:error];
+        [self promptForManualConnection];
     }
 }
 
+- (void)testConnectionAfterHotspotJoin {
+    NSLog(@"🔥 Testing connection after hotspot join");
+    [self updateStatus:@"Testing network connection..." preview:nil];
+
+    // Check if we're actually connected to the target WiFi
+    if ([self isCurrentlyOnTargetWiFi]) {
+        NSLog(@"🔥 Confirmed on target WiFi, proceeding with connection test");
+        [self testConnectionWithQCSDKAndCommonIPs];
+    } else {
+        NSLog(@"🔥 Not on target WiFi, prompting for manual connection");
+        [self promptForManualConnection];
+    }
+}
+
+- (BOOL)isCurrentlyOnTargetWiFi {
+    // Test connectivity to target network instead of checking SSID directly
+    return [self testConnectivityToTargetNetwork];
+}
+
+- (BOOL)testConnectivityToTargetNetwork {
+    // Test if we can reach the glasses device by trying common IPs
+    NSArray *targetIPs = @[@"192.168.43.1", @"192.168.4.1", @"192.168.1.1", @"192.168.0.1"];
+
+    __block BOOL canReachTarget = NO;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+
+    for (NSString *ip in targetIPs) {
+        NSURL *testURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@/files/media.config", ip]];
+        NSURLRequest *request = [NSURLRequest requestWithURL:testURL
+                                                cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
+                                            timeoutInterval:1.0];
+
+        [[[NSURLSession sharedSession] dataTaskWithRequest:request
+                                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
+            if (!error && ((NSHTTPURLResponse *)response).statusCode == 200) {
+                canReachTarget = YES;
+            }
+            dispatch_semaphore_signal(semaphore);
+        }] resume];
+
+        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1.5 * NSEC_PER_SEC)));
+        if (canReachTarget) break;
+    }
+
+    return canReachTarget;
+}
+
+- (void)testConnectionWithQCSDKAndCommonIPs {
+    // First try the QCSDK IP retrieval
+    [QCSDKCmdCreator getDeviceWifiIPSuccess:^(NSString * _Nullable ipAddress) {
+        if (ipAddress.length > 0) {
+            NSLog(@"🔥 Got device IP: %@", ipAddress);
+            [self testConnectionToIP:ipAddress];
+        } else {
+            NSLog(@"🔥 No IP from QCSDK, trying common IPs");
+            [self testConnectionWithCommonIPs];
+        }
+    } failed:^{
+        NSLog(@"🔥 QCSDK IP failed, trying common IPs");
+        [self testConnectionWithCommonIPs];
+    }];
+}
+
+- (void)promptForManualConnection {
+    [self updateStatus:[NSString stringWithFormat:@"Please manually join WiFi: %@", self.ssid] preview:nil];
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(15.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self testConnectionWithCommonIPs];
+    });
+}
+
+- (void)joinHotspot {
+    // Legacy method - redirect to modern config
+    [self joinHotspotWithModernConfig];
+}
+
 - (void)downloadManifest {
-    NSString *manifestString = [NSString stringWithFormat:@"http://%@/files/media.config", self.deviceIP];
+    NSString *manifestString = [NSString stringWithFormat:@"http://%@/files/media.config", self->_deviceIP];
     NSURL *manifestURL = [NSURL URLWithString:manifestString];
     if (!manifestURL) {
         NSError *error = [NSError errorWithDomain:GlassesMediaDownloaderErrorDomain code:GlassesMediaDownloaderErrorCodeManifest userInfo:@{NSLocalizedDescriptionKey : @"Invalid manifest URL."}];
@@ -277,9 +1161,66 @@ typedef NS_ENUM(NSInteger, GlassesMediaDownloaderErrorCode) {
     });
 }
 
+- (void)attemptDelayedModeSwitchWithDelay:(NSTimeInterval)delay attempt:(NSInteger)attempt {
+    NSLog(@"🔥 Attempting delayed mode switch to capture mode (attempt %zd, delay %.1fs)", attempt, delay);
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        [self trySwitchToCaptureModeWithAttempt:attempt];
+    });
+}
+
+- (void)trySwitchToCaptureModeWithAttempt:(NSInteger)attempt {
+    NSLog(@"🔥 Trying to switch to capture mode (attempt %zd)", attempt);
+
+    [QCSDKCmdCreator setDeviceMode:QCOperatorDeviceModePhoto success:^{
+        NSLog(@"🔥 ✅ Successfully returned to capture mode after download (attempt %zd)", attempt);
+        [self updateStatus:@"Successfully returned to capture mode" preview:nil];
+    } fail:^(NSInteger mode) {
+        NSLog(@"🔥 ⚠️ Failed to return to capture mode, current mode: %zd (attempt %zd)", mode, attempt);
+
+        // Try video mode as intermediate step with exponential backoff
+        if (attempt < 5) { // Limit attempts to prevent infinite retry
+            NSTimeInterval nextDelay = 2.0 * pow(2.0, attempt - 1); // 2s, 4s, 8s, 16s
+
+            [self updateStatus:[NSString stringWithFormat:@"Device busy, retrying in %.1fs...", nextDelay] preview:nil];
+
+            // First try video mode, then photo mode
+            [QCSDKCmdCreator setDeviceMode:QCOperatorDeviceModeVideo success:^{
+                NSLog(@"🔥 Switched to video mode, now trying capture mode (attempt %zd)", attempt);
+                [QCSDKCmdCreator setDeviceMode:QCOperatorDeviceModePhoto success:^{
+                    NSLog(@"🔥 ✅ Successfully returned to capture mode via video mode (attempt %zd)", attempt);
+                    [self updateStatus:@"Successfully returned to capture mode" preview:nil];
+                } fail:^(NSInteger photoMode) {
+                    NSLog(@"🔥 ❌ Still failed to return to capture mode, current mode: %zd (attempt %zd)", photoMode, attempt);
+                    // Schedule next attempt with exponential backoff
+                    [self attemptDelayedModeSwitchWithDelay:nextDelay attempt:attempt + 1];
+                }];
+            } fail:^(NSInteger videoMode) {
+                NSLog(@"🔥 ❌ Failed to switch to video mode, current mode: %zd (attempt %zd)", videoMode, attempt);
+                // Schedule next attempt with exponential backoff
+                [self attemptDelayedModeSwitchWithDelay:nextDelay attempt:attempt + 1];
+            }];
+        } else {
+            NSLog(@"🔥 ❌ Max attempts reached, device remains in transfer mode");
+            [self updateStatus:@"Device remains in transfer mode. Please restart if needed." preview:nil];
+        }
+    }];
+}
+
 - (void)finishWithError:(NSError * _Nullable)error {
     if (self.didFinish) { return; }
     self.didFinish = YES;
+
+    // Properly close WiFi connection and return device to capture mode when download completes
+    if (!error) {
+        NSLog(@"🔥 Download completed successfully, closing WiFi connection and returning to capture mode");
+        [self updateStatus:@"Download complete! Returning to capture mode..." preview:nil];
+
+        // Device needs time to transition between WiFi (transfer) and Bluetooth (capture) modes
+        // Implement delayed mode switching with exponential backoff
+        [self attemptDelayedModeSwitchWithDelay:2.0 attempt:1];
+    }
+
     GlassesMediaDownloaderCompletionHandler completion = self.completionHandler;
     if (completion) {
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/ios/QCSDKDemo/Info.plist
+++ b/ios/QCSDKDemo/Info.plist
@@ -6,5 +6,22 @@
 	<array>
 		<string>bluetooth-central</string>
 	</array>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>3.192.168.31</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSExceptionMinimumTLSVersion</key>
+				<string>TLSv1.0</string>
+			</dict>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ios/QCSDKDemo/MediaGalleryViewController.h
+++ b/ios/QCSDKDemo/MediaGalleryViewController.h
@@ -1,0 +1,18 @@
+//
+//  MediaGalleryViewController.h
+//  QCSDKDemo
+//
+//  Created by Claude on 2025/9/24.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MediaGalleryViewController : UIViewController
+
+@property (nonatomic, copy) NSString *mediaDirectoryPath;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/QCSDKDemo/MediaGalleryViewController.m
+++ b/ios/QCSDKDemo/MediaGalleryViewController.m
@@ -1,0 +1,319 @@
+//
+//  MediaGalleryViewController.m
+//  QCSDKDemo
+//
+//  Created by Claude on 2025/9/24.
+//
+
+#import "MediaGalleryViewController.h"
+#import <AVFoundation/AVFoundation.h>
+#import <AVKit/AVKit.h>
+
+@interface MediaGalleryViewController () <UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout>
+
+@property (nonatomic, strong) UICollectionView *collectionView;
+@property (nonatomic, strong) NSArray<NSURL *> *mediaFiles;
+@property (nonatomic, strong) NSMutableArray<UIImage *> *thumbnails;
+@property (nonatomic, strong) UIActivityIndicatorView *loadingIndicator;
+@property (nonatomic, strong) UILabel *emptyLabel;
+
+@end
+
+@implementation MediaGalleryViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"Media Gallery";
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
+
+    [self setupNavigationBar];
+    [self setupCollectionView];
+    [self setupLoadingIndicator];
+    [self setupEmptyLabel];
+
+    [self loadMediaFiles];
+}
+
+- (void)setupNavigationBar {
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                                   target:self
+                                                                                   action:@selector(closeGallery)];
+    self.navigationItem.rightBarButtonItem = closeButton;
+}
+
+- (void)setupCollectionView {
+    UICollectionViewFlowLayout *layout = [[UICollectionViewFlowLayout alloc] init];
+    layout.minimumLineSpacing = 8.0;
+    layout.minimumInteritemSpacing = 8.0;
+
+    CGFloat itemSize = (self.view.bounds.size.width - 32.0) / 3.0;
+    layout.itemSize = CGSizeMake(itemSize, itemSize);
+
+    self.collectionView = [[UICollectionView alloc] initWithFrame:self.view.bounds collectionViewLayout:layout];
+    self.collectionView.backgroundColor = [UIColor systemBackgroundColor];
+    self.collectionView.dataSource = self;
+    self.collectionView.delegate = self;
+    self.collectionView.alwaysBounceVertical = YES;
+
+    [self.collectionView registerClass:[UICollectionViewCell class] forCellWithReuseIdentifier:@"MediaCell"];
+
+    [self.view addSubview:self.collectionView];
+}
+
+- (void)setupLoadingIndicator {
+    self.loadingIndicator = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleLarge];
+    self.loadingIndicator.center = self.view.center;
+    self.loadingIndicator.hidesWhenStopped = YES;
+    [self.view addSubview:self.loadingIndicator];
+}
+
+- (void)setupEmptyLabel {
+    self.emptyLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 300, 100)];
+    self.emptyLabel.center = self.view.center;
+    self.emptyLabel.text = @"No media files found\n\nDownload media from glasses to see them here";
+    self.emptyLabel.textAlignment = NSTextAlignmentCenter;
+    self.emptyLabel.numberOfLines = 0;
+    self.emptyLabel.textColor = [UIColor systemGrayColor];
+    self.emptyLabel.hidden = YES;
+    [self.view addSubview:self.emptyLabel];
+}
+
+- (void)loadMediaFiles {
+    [self.loadingIndicator startAnimating];
+    self.emptyLabel.hidden = YES;
+
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        NSString *mediaDirectoryPath = self.mediaDirectoryPath;
+        if (!mediaDirectoryPath) {
+            // Default to Documents/GlassesMedia
+            NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+            NSString *documentsDirectory = paths.firstObject;
+            mediaDirectoryPath = [documentsDirectory stringByAppendingPathComponent:@"GlassesMedia"];
+        }
+
+        NSURL *mediaDirectoryURL = [NSURL fileURLWithPath:mediaDirectoryPath];
+        NSArray *keys = @[NSURLNameKey, NSURLTypeIdentifierKey, NSURLContentModificationDateKey];
+
+        NSError *error = nil;
+        NSArray *contents = [[NSFileManager defaultManager] contentsOfDirectoryAtURL:mediaDirectoryURL
+                                                              includingPropertiesForKeys:keys
+                                                                                 options:NSDirectoryEnumerationSkipsHiddenFiles
+                                                                                   error:&error];
+
+        NSMutableArray<NSURL *> *mediaFiles = [NSMutableArray array];
+
+        for (NSURL *fileURL in contents) {
+            NSString *fileExtension = fileURL.pathExtension.lowercaseString;
+            if ([@[@"jpg", @"jpeg", @"png", @"heic", @"mov", @"mp4", @"m4v"] containsObject:fileExtension]) {
+                [mediaFiles addObject:fileURL];
+            }
+        }
+
+        // Sort by modification date
+        [mediaFiles sortUsingComparator:^NSComparisonResult(NSURL *url1, NSURL *url2) {
+            NSDate *date1 = nil;
+            NSDate *date2 = nil;
+            [url1 getResourceValue:&date1 forKey:NSURLContentModificationDateKey error:nil];
+            [url2 getResourceValue:&date2 forKey:NSURLContentModificationDateKey error:nil];
+            return [date2 compare:date1]; // Most recent first
+        }];
+
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.loadingIndicator stopAnimating];
+            self.mediaFiles = mediaFiles;
+            [self.collectionView reloadData];
+
+            if (self.mediaFiles.count == 0) {
+                self.emptyLabel.hidden = NO;
+            } else {
+                [self generateThumbnails];
+            }
+        });
+    });
+}
+
+- (void)generateThumbnails {
+    self.thumbnails = [NSMutableArray array];
+
+    for (NSURL *fileURL in self.mediaFiles) {
+        NSString *fileExtension = fileURL.pathExtension.lowercaseString;
+
+        if ([@[@"jpg", @"jpeg", @"png", @"heic"] containsObject:fileExtension]) {
+            // For images, create a thumbnail
+            UIImage *image = [UIImage imageWithContentsOfFile:fileURL.path];
+            if (image) {
+                // Create thumbnail
+                UIGraphicsBeginImageContextWithOptions(CGSizeMake(100, 100), NO, 0.0);
+                [image drawInRect:CGRectMake(0, 0, 100, 100)];
+                UIImage *thumbnail = UIGraphicsGetImageFromCurrentImageContext();
+                UIGraphicsEndImageContext();
+                [self.thumbnails addObject:thumbnail ?: [UIImage new]];
+            } else {
+                [self.thumbnails addObject:[UIImage new]];
+            }
+        } else {
+            // For videos, create a placeholder thumbnail
+            UIImage *videoThumbnail = [self generateVideoThumbnail:fileURL];
+            [self.thumbnails addObject:videoThumbnail];
+        }
+    }
+
+    [self.collectionView reloadData];
+}
+
+- (UIImage *)generateVideoThumbnail:(NSURL *)videoURL {
+    AVAsset *asset = [AVAsset assetWithURL:videoURL];
+    AVAssetImageGenerator *generator = [AVAssetImageGenerator assetImageGeneratorWithAsset:asset];
+    generator.appliesPreferredTrackTransform = YES;
+
+    NSError *error = nil;
+    CGImageRef imageRef = [generator copyCGImageAtTime:kCMTimeZero actualTime:NULL error:&error];
+
+    if (imageRef) {
+        UIImage *image = [UIImage imageWithCGImage:imageRef];
+        CGImageRelease(imageRef);
+        return image;
+    }
+
+    // Return a default video thumbnail
+    return [self createVideoPlaceholderThumbnail];
+}
+
+- (UIImage *)createVideoPlaceholderThumbnail {
+    UIGraphicsBeginImageContextWithOptions(CGSizeMake(100, 100), NO, 0.0);
+    CGContextRef context = UIGraphicsGetCurrentContext();
+
+    // Gray background
+    [[UIColor grayColor] setFill];
+    CGContextFillRect(context, CGRectMake(0, 0, 100, 100));
+
+    // Play icon
+    [[UIColor whiteColor] setFill];
+    CGContextMoveToPoint(context, 35, 25);
+    CGContextAddLineToPoint(context, 35, 75);
+    CGContextAddLineToPoint(context, 70, 50);
+    CGContextClosePath(context);
+    CGContextFillPath(context);
+
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+
+    return image;
+}
+
+#pragma mark - UICollectionViewDataSource
+
+- (NSInteger)collectionView:(UICollectionView *)collectionView numberOfItemsInSection:(NSInteger)section {
+    return self.mediaFiles.count;
+}
+
+- (UICollectionViewCell *)collectionView:(UICollectionView *)collectionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
+    UICollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:@"MediaCell" forIndexPath:indexPath];
+
+    // Clear previous content
+    for (UIView *subview in cell.contentView.subviews) {
+        [subview removeFromSuperview];
+    }
+
+    if (indexPath.row < self.mediaFiles.count) {
+        NSURL *fileURL = self.mediaFiles[indexPath.row];
+        UIImage *thumbnail = (indexPath.row < self.thumbnails.count) ? self.thumbnails[indexPath.row] : nil;
+
+        UIImageView *imageView = [[UIImageView alloc] initWithFrame:CGRectMake(4, 4, cell.contentView.bounds.size.width - 8, cell.contentView.bounds.size.height - 8)];
+        imageView.contentMode = UIViewContentModeScaleAspectFill;
+        imageView.clipsToBounds = YES;
+        imageView.image = thumbnail;
+        imageView.backgroundColor = [UIColor systemGrayColor];
+
+        [cell.contentView addSubview:imageView];
+
+        // Add video badge for video files
+        NSString *fileExtension = fileURL.pathExtension.lowercaseString;
+        if ([@[@"mov", @"mp4", @"m4v"] containsObject:fileExtension]) {
+            UIView *videoBadge = [[UIView alloc] initWithFrame:CGRectMake(imageView.bounds.size.width - 20, imageView.bounds.size.height - 20, 16, 16)];
+            videoBadge.backgroundColor = [UIColor blackColor];
+            videoBadge.alpha = 0.7;
+            videoBadge.layer.cornerRadius = 8;
+
+            UILabel *playLabel = [[UILabel alloc] initWithFrame:videoBadge.bounds];
+            playLabel.text = @"▶";
+            playLabel.textColor = [UIColor whiteColor];
+            playLabel.font = [UIFont systemFontOfSize:8];
+            playLabel.textAlignment = NSTextAlignmentCenter;
+            [videoBadge addSubview:playLabel];
+
+            [imageView addSubview:videoBadge];
+        }
+    }
+
+    return cell;
+}
+
+#pragma mark - UICollectionViewDelegate
+
+- (void)collectionView:(UICollectionView *)collectionView didSelectItemAtIndexPath:(NSIndexPath *)indexPath {
+    if (indexPath.row < self.mediaFiles.count) {
+        NSURL *fileURL = self.mediaFiles[indexPath.row];
+        [self openMediaFile:fileURL];
+    }
+}
+
+- (void)openMediaFile:(NSURL *)fileURL {
+    NSString *fileExtension = fileURL.pathExtension.lowercaseString;
+
+    if ([@[@"jpg", @"jpeg", @"png", @"heic"] containsObject:fileExtension]) {
+        // Open image viewer
+        [self openImageInFullscreen:fileURL];
+    } else if ([@[@"mov", @"mp4", @"m4v"] containsObject:fileExtension]) {
+        // Open video player
+        [self playVideo:fileURL];
+    }
+}
+
+- (void)openImageInFullscreen:(NSURL *)imageURL {
+    UIImage *image = [UIImage imageWithContentsOfFile:imageURL.path];
+    if (!image) return;
+
+    UIViewController *imageViewer = [[UIViewController alloc] init];
+    UIImageView *imageView = [[UIImageView alloc] initWithFrame:imageViewer.view.bounds];
+    imageView.image = image;
+    imageView.contentMode = UIViewContentModeScaleAspectFit;
+    imageView.backgroundColor = [UIColor blackColor];
+    imageView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+
+    [imageViewer.view addSubview:imageView];
+
+    // Add tap to dismiss
+    UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:imageViewer action:@selector(dismissViewControllerAnimated:completion:)];
+    [imageView addGestureRecognizer:tap];
+
+    [self presentViewController:imageViewer animated:YES completion:nil];
+}
+
+- (void)playVideo:(NSURL *)videoURL {
+    AVPlayer *player = [AVPlayer playerWithURL:videoURL];
+    AVPlayerViewController *playerViewController = [[AVPlayerViewController alloc] init];
+    playerViewController.player = player;
+
+    [self presentViewController:playerViewController animated:YES completion:^{
+        [player play];
+    }];
+}
+
+- (void)closeGallery {
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        UICollectionViewFlowLayout *layout = (UICollectionViewFlowLayout *)self.collectionView.collectionViewLayout;
+        CGFloat itemSize = (size.width - 32.0) / 3.0;
+        layout.itemSize = CGSizeMake(itemSize, itemSize);
+        [self.collectionView.collectionViewLayout invalidateLayout];
+    } completion:nil];
+}
+
+@end

--- a/ios/QCSDKDemo/QCSDKDemo.entitlements
+++ b/ios/QCSDKDemo/QCSDKDemo.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.networking.HotspotConfiguration</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add a Wi-Fi media download action to the demo UI so users can trigger transfers and see progress
- implement `GlassesMediaDownloader` to request hotspot credentials, join the glasses network, fetch the manifest, and download files with previews
- register the new helper files with the Xcode project

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2d63cca30832f802bdf24b30a7c0b