### PR TITLE
Add find device anti-loss control

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Key methods:
 - `QCOperatorDeviceModeAudio` - Start audio recording
 - `QCOperatorDeviceModeAudioStop` - Stop audio recording
 - `QCOperatorDeviceModeAIPhoto` - Generate AI image
+- `QCOperatorDeviceModeFindDevice` - Trigger audio/visual alerts to locate misplaced glasses
 
 ## Demo App
 
@@ -115,6 +116,7 @@ The included demo application demonstrates all SDK features:
    - Media count tracking
    - Photo/video/audio capture
    - AI image generation
+   - Anti-loss find-device alerts
 
 ## Permissions
 

--- a/android/GlassesSDKSample/app/src/main/java/com/sdk/glassessdksample/MainActivity.kt
+++ b/android/GlassesSDKSample/app/src/main/java/com/sdk/glassessdksample/MainActivity.kt
@@ -129,7 +129,8 @@ class MainActivity : AppCompatActivity() {
             binding.btnBattery,
             binding.btnVolume,
             binding.btnMediaCount,
-            binding.btnDataDownload
+            binding.btnDataDownload,
+            binding.btnFindDevice
         ) {
             when (this) {
                 binding.btnScan -> {
@@ -357,6 +358,16 @@ class MainActivity : AppCompatActivity() {
                             } else {
                                 //无
                             }
+                        }
+                    }
+                }
+                binding.btnFindDevice -> {
+                    // 触发防丢查找设备，眼镜会响铃并闪烁提示
+                    LargeDataHandler.getInstance().glassesControl(
+                        byteArrayOf(0x02, 0x01, 0x0d)
+                    ) { _, it ->
+                        if (it.dataType == 1 && it.errorCode == 0) {
+                            //执行成功，眼镜发出音频/视觉提醒
                         }
                     }
                 }

--- a/android/GlassesSDKSample/app/src/main/res/layout/acitivyt_main.xml
+++ b/android/GlassesSDKSample/app/src/main/res/layout/acitivyt_main.xml
@@ -79,6 +79,12 @@
     </HorizontalScrollView>
 
     <Button
+        android:id="@+id/btn_find_device"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/text_16" />
+
+    <Button
         android:id="@+id/btn_record"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/android/GlassesSDKSample/app/src/main/res/values/strings.xml
+++ b/android/GlassesSDKSample/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="text_13">音量读取</string>
     <string name="text_14">读取眼镜媒体的数量</string>
     <string name="text_15">BLE+WiFi P2P数据下载</string>
+    <string name="text_16">查找设备（防丢提醒）</string>
 </resources>


### PR DESCRIPTION
## Summary
- add an anti-loss Find Device control to the Android sample UI and wire it to the SDK command
- document the Find Device (0x0D) operator mode and surface the new feature in the README

## Testing
- ⚠️ `./gradlew :app:assembleDebug` *(fails: Android SDK not configured in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68d595a55a9c832fad52983b8fe76340