### PR TITLE
Add find device anti-loss mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Key methods:
 - `QCOperatorDeviceModeAudio` - Start audio recording
 - `QCOperatorDeviceModeAudioStop` - Stop audio recording
 - `QCOperatorDeviceModeAIPhoto` - Generate AI image
+- `QCOperatorDeviceModeFindDevice` - Trigger anti-loss audio/visual alert
 
 ## Demo App
 
@@ -114,6 +115,7 @@ The included demo application demonstrates all SDK features:
    - Battery status monitoring
    - Media count tracking
    - Photo/video/audio capture
+   - Anti-loss find device alerts
    - AI image generation
 
 ## Permissions

--- a/examples/ios/GlassesFramework/BluetoothManager.swift
+++ b/examples/ios/GlassesFramework/BluetoothManager.swift
@@ -22,6 +22,11 @@ public enum DeviceOperationMode: Int {
     case aiPhoto = 0x06
     case speechRecognition = 0x07
     case audio = 0x08
+    case transferStop = 0x09
+    case factoryReset = 0x0A
+    case speechRecognitionStop = 0x0B
+    case audioStop = 0x0C
+    case findDevice = 0x0D
     
     var qcMode: QCOperatorDeviceMode {
         return QCOperatorDeviceMode(rawValue: self.rawValue) ?? .unkown
@@ -53,6 +58,7 @@ public enum DeviceActionType: Int, CaseIterable {
     case toggleVideoRecording
     case toggleAudioRecording
     case takeAIImage
+    case findDevice
     
     public var title: String {
         switch self {
@@ -72,6 +78,8 @@ public enum DeviceActionType: Int, CaseIterable {
             return "Toggle Audio Recording"
         case .takeAIImage:
             return "Take AI Image"
+        case .findDevice:
+            return "Find My Glasses"
         }
     }
 }
@@ -282,7 +290,7 @@ public class BluetoothManager: NSObject, ObservableObject {
             print("Failed to toggle audio, current mode: \(mode)")
         })
     }
-    
+
     public func takeAIImage() {
         print("📸 Requesting AI image capture...")
         QCSDKCmdCreator.setDeviceMode(.aiPhoto, success: {
@@ -298,6 +306,16 @@ public class BluetoothManager: NSObject, ObservableObject {
                     userInfo: ["error": "Device is in mode \(mode)"]
                 )
             }
+        })
+    }
+
+    /// Triggers the device's anti-loss locator alert which plays audio and flashes LEDs.
+    public func findDevice() {
+        print("📢 Triggering find device alert...")
+        QCSDKCmdCreator.setDeviceMode(.findDevice, success: {
+            print("✅ Find device alert sent")
+        }, fail: { mode in
+            print("❌ Failed to trigger find device alert, current mode: \(mode)")
         })
     }
 }

--- a/examples/ios/GlassesFramework/GlassesFramework.docc/GlassesFramework.md
+++ b/examples/ios/GlassesFramework/GlassesFramework.docc/GlassesFramework.md
@@ -92,6 +92,9 @@ The framework is built with a modular architecture:
 - ``BluetoothManager/toggleVideoRecording()``
 - ``BluetoothManager/toggleAudioRecording()``
 - ``BluetoothManager/takeAIImage()``
+- ``BluetoothManager/findDevice()``
+
+`findDevice()` activates the glasses' anti-loss safety mode by playing a loud audio cue and flashing the onboard LEDs so users can quickly locate misplaced hardware.
 
 ### Audio and Volume Control
 

--- a/examples/ios/GlassesFrameworkTests/UnitTests/DeviceActionTypeTests.swift
+++ b/examples/ios/GlassesFrameworkTests/UnitTests/DeviceActionTypeTests.swift
@@ -19,6 +19,7 @@ class DeviceActionTypeTests: XCTestCase {
         XCTAssertEqual(DeviceActionType.toggleVideoRecording.rawValue, 5)
         XCTAssertEqual(DeviceActionType.toggleAudioRecording.rawValue, 6)
         XCTAssertEqual(DeviceActionType.takeAIImage.rawValue, 7)
+        XCTAssertEqual(DeviceActionType.findDevice.rawValue, 8)
     }
     
     func testDeviceActionTypeTitles() {
@@ -30,10 +31,11 @@ class DeviceActionTypeTests: XCTestCase {
         XCTAssertEqual(DeviceActionType.toggleVideoRecording.title, "Toggle Video Recording")
         XCTAssertEqual(DeviceActionType.toggleAudioRecording.title, "Toggle Audio Recording")
         XCTAssertEqual(DeviceActionType.takeAIImage.title, "Take AI Image")
+        XCTAssertEqual(DeviceActionType.findDevice.title, "Find My Glasses")
     }
     
     func testAllCasesCount() {
-        XCTAssertEqual(DeviceActionType.allCases.count, 8)
+        XCTAssertEqual(DeviceActionType.allCases.count, 9)
     }
     
     func testAllCasesContainsAllTypes() {
@@ -47,6 +49,7 @@ class DeviceActionTypeTests: XCTestCase {
         XCTAssertTrue(allCases.contains(.toggleVideoRecording))
         XCTAssertTrue(allCases.contains(.toggleAudioRecording))
         XCTAssertTrue(allCases.contains(.takeAIImage))
+        XCTAssertTrue(allCases.contains(.findDevice))
     }
     
     func testIterationOverAllCases() {
@@ -54,7 +57,7 @@ class DeviceActionTypeTests: XCTestCase {
         for _ in DeviceActionType.allCases {
             count += 1
         }
-        XCTAssertEqual(count, 8)
+        XCTAssertEqual(count, 9)
     }
     
     func testTitleUniqueness() {

--- a/examples/legacy/HeyCyanSwift/Views/DeviceActionsListView.swift
+++ b/examples/legacy/HeyCyanSwift/Views/DeviceActionsListView.swift
@@ -93,9 +93,10 @@ private struct StandardActionRow: View {
         case .toggleVideoRecording: return "video"
         case .toggleAudioRecording: return "mic"
         case .takeAIImage: return "sparkles"
+        case .findDevice: return "dot.radiowaves.left.and.right"
         }
     }
-    
+
     private var detailText: String? {
         let info = bluetoothManager.deviceInfo
         
@@ -119,6 +120,8 @@ private struct StandardActionRow: View {
             return info.isRecordingVideo ? "Recording..." : "Tap to start recording"
         case .toggleAudioRecording:
             return info.isRecordingAudio ? "Recording..." : "Tap to start recording"
+        case .findDevice:
+            return "Play loud audio and flash LEDs to locate nearby glasses."
         default:
             return nil
         }
@@ -143,6 +146,8 @@ private struct StandardActionRow: View {
             bluetoothManager.toggleAudioRecording()
         case .takeAIImage:
             bluetoothManager.takeAIImage()
+        case .findDevice:
+            bluetoothManager.findDevice()
         }
     }
 }


### PR DESCRIPTION
## Summary
- expose the QCOperatorDeviceModeFindDevice command through the Swift BluetoothManager API
- surface the anti-loss alert in the sample UI with descriptive copy and SF Symbol iconography
- document the new capability and extend unit tests to cover the additional DeviceActionType case

## Testing
- not run (requires xcodebuild which is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d595a55a9c832fad52983b8fe76340