### PR TITLE
Fix audio recording toggle condition

### DIFF
--- a/ios/QCSDKDemo/ViewController.m
+++ b/ios/QCSDKDemo/ViewController.m
@@ -225,7 +225,7 @@ typedef NS_ENUM(NSInteger, QGDeviceActionType) {
 }
 
 - (void)recordAudio {
-    if (self.recordingVideo) {
+    if (self.recordingAudio) {
         [QCSDKCmdCreator setDeviceMode:(QCOperatorDeviceModeAudioStop) success:^{
             self.recordingAudio = NO;
             [self.tableView reloadData];


### PR DESCRIPTION
## Summary
- correct the audio recording toggle to check the audio recording state before issuing stop/start commands

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5969432b8832f875c20b4704a6091