### PR TITLE
Add Power-Off Functionality for HeyCyan Smart Glasses

### DIFF
--- a/ios/QCSDKDemo/ViewController.m
+++ b/ios/QCSDKDemo/ViewController.m
@@ -53,6 +53,9 @@ typedef NS_ENUM(NSInteger, QGDeviceActionType) {
     /// View downloaded media gallery
     QGDeviceActionTypeViewGallery,
 
+    /// Power off glasses (turn off Bluetooth)
+    QGDeviceActionTypePowerOff,
+
     /// Reserved for future use
     QGDeviceActionTypeReserved,
 };
@@ -394,6 +397,11 @@ typedef NS_ENUM(NSInteger, QGDeviceActionType) {
             cell.textLabel.text = @"View Media Gallery";
             cell.detailTextLabel.text = @"Browse and view downloaded photos and videos.";
             break;
+        case QGDeviceActionTypePowerOff:
+            cell.textLabel.text = @"Power Off Glasses";
+            cell.detailTextLabel.text = @"Turn off the glasses' Bluetooth module.";
+            cell.textLabel.textColor = [UIColor redColor];
+            break;
         case QGDeviceActionTypeReserved:
             break;
         default:
@@ -437,6 +445,9 @@ typedef NS_ENUM(NSInteger, QGDeviceActionType) {
             break;
         case QGDeviceActionTypeViewGallery:
             [self openMediaGallery];
+            break;
+        case QGDeviceActionTypePowerOff:
+            [self powerOffGlasses];
             break;
         case QGDeviceActionTypeSwitchToCaptureMode:
             [self switchToCaptureMode];
@@ -555,6 +566,62 @@ typedef NS_ENUM(NSInteger, QGDeviceActionType) {
         NSLog(@"Failed to switch to transfer mode, current mode: %zd", mode);
         [self.tableView reloadData];
     }];
+}
+
+- (void)powerOffGlasses {
+    NSLog(@"Powering off glasses...");
+
+    // Show confirmation alert
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:@"Power Off Glasses"
+                                                                   message:@"Are you sure you want to turn off the glasses' Bluetooth module? This will disconnect the device."
+                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *cancelAction = [UIAlertAction actionWithTitle:@"Cancel"
+                                                           style:UIAlertActionStyleCancel
+                                                         handler:nil];
+
+    UIAlertAction *powerOffAction = [UIAlertAction actionWithTitle:@"Power Off"
+                                                             style:UIAlertActionStyleDestructive
+                                                           handler:^(UIAlertAction * _Nonnull action) {
+        NSLog(@"Sending power off command to glasses...");
+
+        [QCSDKCmdCreator setDeviceMode:QCOperatorDeviceModeTransferStop
+                               success:^{
+            NSLog(@"✅ Glasses Bluetooth turned off successfully");
+
+            // Show success message
+            UIAlertController *successAlert = [UIAlertController alertControllerWithTitle:@"Success"
+                                                                                   message:@"Glasses have been powered off. The device should now be disconnected."
+                                                                            preferredStyle:UIAlertControllerStyleAlert];
+
+            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
+                                                               style:UIAlertActionStyleDefault
+                                                             handler:nil];
+
+            [successAlert addAction:okAction];
+            [self presentViewController:successAlert animated:YES completion:nil];
+
+        } fail:^(NSInteger mode) {
+            NSLog(@"❌ Failed to power off glasses, current mode: %zd", mode);
+
+            // Show error message
+            UIAlertController *errorAlert = [UIAlertController alertControllerWithTitle:@"Error"
+                                                                                  message:[NSString stringWithFormat:@"Failed to power off glasses. Current device mode: %zd", mode]
+                                                                           preferredStyle:UIAlertControllerStyleAlert];
+
+            UIAlertAction *okAction = [UIAlertAction actionWithTitle:@"OK"
+                                                               style:UIAlertActionStyleDefault
+                                                             handler:nil];
+
+            [errorAlert addAction:okAction];
+            [self presentViewController:errorAlert animated:YES completion:nil];
+        }];
+    }];
+
+    [alert addAction:cancelAction];
+    [alert addAction:powerOffAction];
+
+    [self presentViewController:alert animated:YES completion:nil];
 }
 
 @end


### PR DESCRIPTION
## Summary
- Add power-off control feature for HeyCyan smart glasses
- Implement user interface button with confirmation dialog
- Use proprietary BLE command to turn off glasses Bluetooth module

## Implementation Details
- Added `QGDeviceActionTypePowerOff` enum to device action types
- Created `powerOffGlasses` method with confirmation alert dialog
- Implemented success and error handling with user feedback
- Used `QCOperatorDeviceModeTransferStop` command to power off glasses
- Styled power-off button with red text to indicate destructive action

## User Experience
- Confirmation dialog prevents accidental power-offs
- Clear success/error messages with detailed feedback
- Console logging for debugging purposes
- Destructive action appropriately styled

## Technical Notes
- Utilizes existing QCSDK framework and BLE communication
- Leverages `QCOperatorDeviceModeTransferStop` mode (0x63) to turn off Bluetooth
- Maintains consistency with existing app architecture and UI patterns
- Graceful handling of both success and failure scenarios

## Test Plan
- [ ] Test power-off functionality with connected HeyCyan glasses
- [ ] Verify confirmation dialog appears correctly
- [ ] Test success scenario with proper feedback
- [ ] Test error handling when device is busy or unavailable
- [ ] Verify UI updates appropriately after power-off command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a “Power Off Glasses” action in the device actions list.
  - Displays a confirmation dialog before powering off.
  - Shows success and error alerts, including information about expected disconnection behavior when Bluetooth turns off.
  - Integrates the action into the existing selection flow for seamless access.
- UI
  - Introduced a distinct red-labeled row with a helpful subtitle to clearly indicate the power-off option and its implications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->